### PR TITLE
Optimzed reinitialization test case

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -912,7 +912,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       checkInputProps(inputRender.calls[ 2 ].arguments[ 0 ], 'baz', false)
     })
 
-    it.only('should be pristine after initialize() if enableReinitialize', () => {
+    it('should be pristine after initialize() if enableReinitialize', () => {
       const store = makeStore({})
       const inputRender = createSpy(props => <input {...props.input}/>).andCallThrough()
       const formRender = createSpy()

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -622,6 +622,14 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       }
 
       const dom = TestUtils.renderIntoDocument(<Container/>)
+
+      const checkInputProps = (props, value, pristine = true, dirty = false) => {
+        expect(props.meta.pristine).toBe(pristine)
+        expect(props.meta.dirty).toBe(dirty)
+        expect(props.input.value).toBe(value)
+      }
+
+      // Check initial state
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
@@ -631,34 +639,36 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           }
         }
       })
+
+      // Expect rerenders due to initialization.
       expect(formRender).toHaveBeenCalled()
       expect(formRender.calls.length).toBe(1)
 
       expect(inputRender).toHaveBeenCalled()
-      expect(inputRender.calls.length).toBe(1)
-      const checkInputProps = (props, value, pristine = true, dirty = false) => {
-        expect(props.meta.pristine).toBe(pristine)
-        expect(props.meta.dirty).toBe(dirty)
-        expect(props.input.value).toBe(value)
-      }
+      expect(inputRender.calls.length).toBe(1)      
+
+      // Expect that input value has been initialized
       checkInputProps(inputRender.calls[ 0 ].arguments[ 0 ], 'bar')
 
       // change input value and check if it is dirty and not pristine
       const onChange = inputRender.calls[ 0 ].arguments[ 0 ].input.onChange
       onChange('dirtyvalue')
 
+      // Expect rerenders due to the change.
       expect(formRender).toHaveBeenCalled()
       expect(formRender.calls.length).toBe(2)
 
       expect(inputRender).toHaveBeenCalled()
       expect(inputRender.calls.length).toBe(2)
+
+      // Expect that input value has been changed
       checkInputProps(inputRender.calls[ 1 ].arguments[ 0 ], 'dirtyvalue', false, true)
 
-      // re-initialize form and check if it pristine and not dirty
+      // Re-initialize form and check if it pristine and not dirty
       const initButton = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
       TestUtils.Simulate.click(initButton)
 
-      // check initialized state
+      // Check re-initialized state
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
@@ -674,11 +684,14 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         }
       })
 
+      // Expect rerenders due to the re-initialization.
       expect(formRender).toHaveBeenCalled()
-      expect(formRender.calls.length).toBe(3) // form should not 
+      expect(formRender.calls.length).toBe(3)
 
       expect(inputRender).toHaveBeenCalled()
       expect(inputRender.calls.length).toBe(3)
+
+      // Expect that input value has been re-initialized
       checkInputProps(inputRender.calls[ 2 ].arguments[ 0 ], 'baz')
     })
 

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -636,14 +636,25 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(inputRender).toHaveBeenCalled()
       expect(inputRender.calls.length).toBe(1)
-      const checkInputProps = (props, value) => {
-        expect(props.meta.pristine).toBe(true)
-        expect(props.meta.dirty).toBe(false)
+      const checkInputProps = (props, value, pristine = true, dirty = false) => {
+        expect(props.meta.pristine).toBe(pristine)
+        expect(props.meta.dirty).toBe(dirty)
         expect(props.input.value).toBe(value)
       }
       checkInputProps(inputRender.calls[ 0 ].arguments[ 0 ], 'bar')
 
-      // initialize
+      // change input value and check if it is dirty and not pristine
+      const onChange = inputRender.calls[ 0 ].arguments[ 0 ].input.onChange
+      onChange('dirtyvalue')
+
+      expect(formRender).toHaveBeenCalled()
+      expect(formRender.calls.length).toBe(2)
+
+      expect(inputRender).toHaveBeenCalled()
+      expect(inputRender.calls.length).toBe(2)
+      checkInputProps(inputRender.calls[ 1 ].arguments[ 0 ], 'dirtyvalue', false, true)
+
+      // re-initialize form and check if it pristine and not dirty
       const initButton = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
       TestUtils.Simulate.click(initButton)
 
@@ -663,16 +674,12 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         }
       })
 
+      expect(formRender).toHaveBeenCalled()
+      expect(formRender.calls.length).toBe(3) // form should not 
 
-      // Latest value should be `baz`
-      checkInputProps(inputRender.calls[ inputRender.calls.length - 1 ].arguments[ 0 ], 'baz')
-
-      // TODO note from ncphillips: I'm pretty skeptical that these are useful assertion
-      // should rerender input with new value
-      expect(inputRender.calls.length).toBe(2)
-      
-      // rerendered twice because prop changed and values initialized
-      expect(formRender.calls.length).toBe(3)
+      expect(inputRender).toHaveBeenCalled()
+      expect(inputRender.calls.length).toBe(3)
+      checkInputProps(inputRender.calls[ 2 ].arguments[ 0 ], 'baz')
     })
 
     it('should retain dirty fields if keepDirtyOnReinitialize is set', () => {

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -640,7 +640,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         }
       })
 
-      // Expect rerenders due to initialization.
+      // Expect renders due to initialization.
       expect(formRender).toHaveBeenCalled()
       expect(formRender.calls.length).toBe(1)
 
@@ -650,7 +650,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       // Expect that input value has been initialized
       checkInputProps(inputRender.calls[ 0 ].arguments[ 0 ], 'bar')
 
-      // change input value and check if it is dirty and not pristine
+      // Change input value and check if it is dirty and not pristine
       const onChange = inputRender.calls[ 0 ].arguments[ 0 ].input.onChange
       onChange('dirtyvalue')
 
@@ -661,10 +661,10 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(inputRender).toHaveBeenCalled()
       expect(inputRender.calls.length).toBe(2)
 
-      // Expect that input value has been changed
+      // Expect that input value has been changed and is dirty now
       checkInputProps(inputRender.calls[ 1 ].arguments[ 0 ], 'dirtyvalue', false, true)
 
-      // Re-initialize form and check if it pristine and not dirty
+      // Re-initialize form and check if it is pristine and not dirty
       const initButton = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
       TestUtils.Simulate.click(initButton)
 
@@ -691,7 +691,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(inputRender).toHaveBeenCalled()
       expect(inputRender.calls.length).toBe(3)
 
-      // Expect that input value has been re-initialized
+      // Expect that input value has been re-initialized and is not dirty anymore
       checkInputProps(inputRender.calls[ 2 ].arguments[ 0 ], 'baz')
     })
 

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -3129,4 +3129,4 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 }
 
 describeReduxForm('reduxForm.plain', plain, plainCombineReducers, addExpectations(plainExpectations))
-// describeReduxForm('reduxForm.immutable', immutable, immutableCombineReducers, addExpectations(immutableExpectations))
+describeReduxForm('reduxForm.immutable', immutable, immutableCombineReducers, addExpectations(immutableExpectations))

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -258,13 +258,13 @@ const createReduxForm =
               const isBlurredField = !submitting &&
                 (!asyncBlurFields || ~asyncBlurFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]')))
               if ((isBlurredField || submitting) && shouldAsyncValidate({
-                  asyncErrors,
-                  initialized,
-                  trigger: submitting ? 'submit' : 'blur',
-                  blurredField: name,
-                  pristine,
-                  syncValidationPasses
-                })) {
+                asyncErrors,
+                initialized,
+                trigger: submitting ? 'submit' : 'blur',
+                blurredField: name,
+                pristine,
+                syncValidationPasses
+              })) {
                 return asyncValidation(
                   () => asyncValidate(valuesToValidate, dispatch, this.props, name),
                   startAsyncValidation,


### PR DESCRIPTION
I have optimized the test case and it seems to work as expected. I have triggered a change to the input field value after the first initialization to check if the re-initialization is keeping any unexpected dirty or pristine flags.

I think it's a good idea to keep those render call checks to let the tests fail if you somehow create a render loop or your form re-renders when it shouldn't. 
